### PR TITLE
Get image size from topic instead of rosparam

### DIFF
--- a/scripts/image_undistortion.py
+++ b/scripts/image_undistortion.py
@@ -36,8 +36,6 @@ class ImageUndistortion:
         self.mf.registerCallback(self._img_callback)
         self._pub_rect_img_l = rospy.Publisher("/camera_l/image_rect_color", Image, queue_size=1)
         self._pub_rect_img_r = rospy.Publisher("/camera_r/image_rect_color", Image, queue_size=1)
-        self._captured_img_width = rosparam.get_param("/csi_cam_0/image_width")
-        self._captured_img_height = rosparam.get_param("/csi_cam_0/image_height")
 
         camera_param = np.load('{}/config/camera_param_fisheye.npz'.format(rospkg.RosPack().get_path('jnmouse_ros_examples')))
         mtx_l, dist_l, mtx_r, dist_r, R, T = [camera_param[i] for i in ["mtx_l", "dist_l", "mtx_r", "dist_r", "R", "T"]]
@@ -52,6 +50,8 @@ class ImageUndistortion:
 
     def _img_callback(self, img_l, img_r):
         try:
+            self._captured_img_height = img_l.height
+            self._captured_img_width = img_l.width
             self._captured_img_l = self._cv_bridge.imgmsg_to_cv2(img_l, "bgr8")
             self._captured_img_r = self._cv_bridge.imgmsg_to_cv2(img_r, "bgr8")
         except CvBridgeError as e:

--- a/scripts/image_undistortion.py
+++ b/scripts/image_undistortion.py
@@ -22,7 +22,6 @@ import numpy as np
 import copy
 import message_filters
 from sensor_msgs.msg import Image
-import rosparam
 from cv_bridge import CvBridge, CvBridgeError
 
 class ImageUndistortion:
@@ -30,12 +29,22 @@ class ImageUndistortion:
         self._cv_bridge = CvBridge()
         self._captured_img_l = None
         self._captured_img_r = None
-        sub_img_l = message_filters.Subscriber("/csi_cam_0/image_raw", Image)
-        sub_img_r = message_filters.Subscriber("/csi_cam_1/image_raw", Image)
+        self._captured_img_height = 1
+        self._captured_img_width = 1
+        self._left_camera_image_topic = "/csi_cam_0/image_raw"
+        self._right_camera_image_topic = "/csi_cam_1/image_raw"
+        sub_img_l = message_filters.Subscriber(self._left_camera_image_topic, Image)
+        sub_img_r = message_filters.Subscriber(self._right_camera_image_topic, Image)
         self.mf = message_filters.ApproximateTimeSynchronizer([sub_img_l, sub_img_r], 100, 10.0)
         self.mf.registerCallback(self._img_callback)
         self._pub_rect_img_l = rospy.Publisher("/camera_l/image_rect_color", Image, queue_size=1)
         self._pub_rect_img_r = rospy.Publisher("/camera_r/image_rect_color", Image, queue_size=1)
+
+        rospy.loginfo("waiting for left camera image")
+        rospy.wait_for_message(self._left_camera_image_topic, Image)
+        rospy.loginfo("waiting for right camera image")
+        rospy.wait_for_message(self._right_camera_image_topic, Image)
+        rospy.loginfo("camera image topic received")
 
         camera_param = np.load('{}/config/camera_param_fisheye.npz'.format(rospkg.RosPack().get_path('jnmouse_ros_examples')))
         mtx_l, dist_l, mtx_r, dist_r, R, T = [camera_param[i] for i in ["mtx_l", "dist_l", "mtx_r", "dist_r", "R", "T"]]
@@ -78,6 +87,7 @@ class ImageUndistortion:
 
         else:
             rospy.loginfo('There is no valid captured image')
+
 
 if __name__ == '__main__':
     rospy.init_node('image_undistortion')

--- a/scripts/stereo_depth_estimation.py
+++ b/scripts/stereo_depth_estimation.py
@@ -72,6 +72,8 @@ class StereoDepthEstimator:
 
     def _img_callback(self, img_l, img_r):
         try:
+            self._captured_img_height = img_l.height
+            self._captured_img_width = img_l.width
             self._captured_img_l = self._cv_bridge.imgmsg_to_cv2(img_l, "bgr8")
             self._captured_img_r = self._cv_bridge.imgmsg_to_cv2(img_r, "bgr8")
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

scripts/image_undistortion.py においてrosparamから画像の縦横のサイズを取得していますが、以下の理由からトピックから直接画像サイズを取得します。
* rosparamはROSのトピックにかかわらず書き換え可能であること
* rosbagではrosparamは記録されないこと

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

https://github.com/rt-net/jnmouse_ros_examples/blob/b1bc0a540a33080fd511e854a6f91eee7e967654/scripts/image_undistortion.py#L51-L58

```diff
            self._captured_img_height = img_l.height
            self._captured_img_width = img_l.width
+           print(self._captured_img_width, self._captured_img_height)
            self._captured_img_l = self._cv_bridge.imgmsg_to_cv2(img_l, "bgr8"
```

上記のように変更してrosparamと同じサイズが取得できたことを確認しました。

また、以下のコマンドを実行して問題なく歪み補正ができていることを確認しています。

```
roslaunch jnmouse_ros_examples image_undistortion.launch
```





# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
